### PR TITLE
Remove duplicate item in devices.yml.

### DIFF
--- a/test/data/devices.yml
+++ b/test/data/devices.yml
@@ -183,10 +183,6 @@ iHeartRadio/7.3.3 (Android Sdk 21):
   - iHeartRadio
   - Android Phone
   - Mobile
-iHeartRadio/8.9.1 (iPad; iOS 11.2.6; iPad6,7):
-  - iHeartRadio
-  - Apple iPad
-  - Mobile
 CastBox/0.2.0 python-requests/2.20.1:
   - CastBox
   - Unknown Computer


### PR DESCRIPTION
iHeartRadio/8.9.1 (iPad; iOS 11.2.6; iPad6,7) was in the file twice with the same attributes, preventing strict parsers from loading.